### PR TITLE
redfish validator: semantic fix on update service

### DIFF
--- a/svc-update/update/getresources.go
+++ b/svc-update/update/getresources.go
@@ -91,7 +91,7 @@ func (e *ExternalInterface) GetUpdateService() response.RPC {
 		SoftwareInventory: uresponse.SoftwareInventory{
 			OdataID: "/redfish/v1/UpdateService/SoftwareInventory",
 		},
-		Action: uresponse.Action{
+		Actions: uresponse.Actions{
 			UpdateServiceSimpleUpdate: uresponse.UpdateServiceSimpleUpdate{
 				Target: "/redfish/v1/UpdateService/Actions/SimpleUpdate",
 			},
@@ -124,8 +124,8 @@ func (e *ExternalInterface) GetAllFirmwareInventory(req *updateproto.UpdateReque
 		Description:  "FirmwareInventory view",
 		Name:         "FirmwareInventory",
 	}
-	var members []dmtf.Link
 
+	members := []dmtf.Link{}
 	firmwareCollectionKeysArray, err := e.DB.GetAllKeysFromTable("FirmwareInventory", common.InMemory)
 	if err != nil || len(firmwareCollectionKeysArray) == 0 {
 		log.Warn("odimra doesnt have servers")
@@ -217,8 +217,8 @@ func (e *ExternalInterface) GetAllSoftwareInventory(req *updateproto.UpdateReque
 		Description:  "SoftwareInventory view",
 		Name:         "SoftwareInventory",
 	}
-	var members []dmtf.Link
 
+	members := []dmtf.Link{}
 	softwareCollectionKeysArray, err := e.DB.GetAllKeysFromTable("SoftwareInventory", common.InMemory)
 	if err != nil || len(softwareCollectionKeysArray) == 0 {
 		log.Warn("odimra doesnt have servers")

--- a/svc-update/update/getresources_test.go
+++ b/svc-update/update/getresources_test.go
@@ -151,7 +151,7 @@ func TestGetUpdateService(t *testing.T) {
 					FirmwareInventory: uresponse.FirmwareInventory{
 						OdataID: "/redfish/v1/UpdateService/FirmwareInventory",
 					},
-					Action: uresponse.Action{
+					Actions: uresponse.Actions{
 						UpdateServiceSimpleUpdate: uresponse.UpdateServiceSimpleUpdate{
 							Target: "/redfish/v1/UpdateService/Actions/SimpleUpdate",
 						},
@@ -190,7 +190,7 @@ func TestGetUpdateService(t *testing.T) {
 					FirmwareInventory: uresponse.FirmwareInventory{
 						OdataID: "/redfish/v1/UpdateService/FirmwareInventory",
 					},
-					Action: uresponse.Action{
+					Actions: uresponse.Actions{
 						UpdateServiceSimpleUpdate: uresponse.UpdateServiceSimpleUpdate{
 							Target: "/redfish/v1/UpdateService/Actions/SimpleUpdate",
 						},

--- a/svc-update/uresponse/updateservice.go
+++ b/svc-update/uresponse/updateservice.go
@@ -48,8 +48,8 @@ type UpdateServiceStartUpdate struct {
 	ActionInfo string `json:"@Redfish.ActionInfo,omitempty"`
 }
 
-// Action defines the links to the actions available under the service
-type Action struct {
+// Actions defines the links to the actions available under the service
+type Actions struct {
 	UpdateServiceSimpleUpdate UpdateServiceSimpleUpdate `json:"#UpdateService.SimpleUpdate"`
 	UpdateServiceStartUpdate  UpdateServiceStartUpdate  `json:"#UpdateService.StartUpdate"`
 }
@@ -62,7 +62,7 @@ type UpdateService struct {
 	HttpPushUri       string            `json:"HttpPushUri"`
 	FirmwareInventory FirmwareInventory `json:"FirmwareInventory"`
 	SoftwareInventory SoftwareInventory `json:"SoftwareInventory"`
-	Action            Action            `json:"Action"`
+	Actions           Actions           `json:"Actions"`
 	OEM               *OEM              `json:"Oem,omitempty"`
 }
 


### PR DESCRIPTION
This PR contains the following fixes:

- Actions field to fixed from 'Action' to 'Actions'

- Members of Firmware/Software inventory to return an empty list rather than null